### PR TITLE
24 file chooser crashing on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can also use `build`, `run` or `clean` after make.
 Use this command-line in a powershell terminal:
 
 ```powershell
-$env:CGO_ENABLED=1; go build -ldflags "-H windowsgui" -o BOMulus.exe cmd/BOMulus/main.go
+$env:CGO_ENABLED=1; go build -ldflags "-H windowsgui" -o build/BOMulus-win-<version>/BOMulus.exe cmd/BOMulus/main.go
 ```
 
 You can also decide to create the build into a build/windows directory.
@@ -79,13 +79,13 @@ You can also decide to create the build into a build/windows directory.
 To deploy the build you'll also need to copy dll's into the .exe folder:
 
 ```powershell
-cp /tools/msys64/mingw64/bin/*.dll "C:\Users\<username>\Documents\BOMulus\BOMulus-win-v0.0.1-alpha"
+robocopy "\tools\msys64\mingw64\bin" "build\BOMulus-win-<version>\bin" *dll
 ```
-
-or maybe
-
 ```powershell
-cp /msys64/mingw64/bin/*.dll "C:\Users\<username>\Documents\BOMulus\BOMulus-win-v0.0.1-alpha"
+robocopy "\tools\msys64\mingw64\share\glib-2.0" "build\BOMulus-win-<version>\share\glib-2.0" /E
+```
+```powershell
+robocopy "\tools\msys64\mingw64\share\icons" "build\BOMulus-win-<version>\share\icons" /E
 ```
 
 ### 🚀 Running

--- a/cmd/BOMulus/main.go
+++ b/cmd/BOMulus/main.go
@@ -7,18 +7,17 @@ import (
 	"runtime"
 )
 
+// Define the Gsettings schemas dir in the env path.
 func init() {
 	if runtime.GOOS == "windows" {
-		// Obtenez le chemin de l'exécutable
+		// Get executable path.
 		exePath, err := os.Executable()
 		if err != nil {
 			panic(err)
 		}
-
-		// Construisez le chemin vers le dossier des schémas
+		// GSettings schemas path.
 		schemaDir := filepath.Join(filepath.Dir(exePath), "share", "glib-2.0", "schemas")
-
-		// Définissez la variable d'environnement
+		// Define env path.
 		err = os.Setenv("GSETTINGS_SCHEMA_DIR", schemaDir)
 		if err != nil {
 			panic(err)

--- a/cmd/BOMulus/main.go
+++ b/cmd/BOMulus/main.go
@@ -2,7 +2,29 @@ package main
 
 import (
 	"gui"
+	"os"
+	"path/filepath"
+	"runtime"
 )
+
+func init() {
+	if runtime.GOOS == "windows" {
+		// Obtenez le chemin de l'exécutable
+		exePath, err := os.Executable()
+		if err != nil {
+			panic(err)
+		}
+
+		// Construisez le chemin vers le dossier des schémas
+		schemaDir := filepath.Join(filepath.Dir(exePath), "share", "glib-2.0", "schemas")
+
+		// Définissez la variable d'environnement
+		err = os.Setenv("GSETTINGS_SCHEMA_DIR", schemaDir)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
 
 func main() {
 	gui.GuiInit()

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -23,7 +23,7 @@ func Export(selectedPath, fileName string, deleteChecked, insertChecked, updateC
 			originalFile[i] = strings.TrimPrefix(originalFile[i], "/")
 		}
 	}
-	copiedFile := "BOMulus-" + fileName + filepath.Ext(originalFile[1])
+	copiedFile := selectedPath + "BOMulus-" + fileName + filepath.Ext(originalFile[1])
 	// Copy original file.
 	err := core.CopyFile(originalFile[1], copiedFile)
 	if err != nil {
@@ -299,7 +299,7 @@ func Export(selectedPath, fileName string, deleteChecked, insertChecked, updateC
 		}
 	}
 	// Save copied and modified file.
-	err = f.SaveAs(selectedPath + copiedFile)
+	err = f.SaveAs(copiedFile)
 	if err != nil {
 		fmt.Println(err)
 		return


### PR DESCRIPTION
- Issue fixed by creating an Init function, which is executed before the main function, to define the GSettings schemas environment path.
- Additionally, a small fix was made to the export function to avoid file duplication.
- The README has been updated to facilitate the build process.
