### PR TITLE
31 components detection

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,3 +52,28 @@ const (
 	SUMMARY_SPACING string = "              "
 	LOGO_PATH       string = "assets/logo.png"
 )
+
+var (
+	HEADER_KEYWORDS = []string{
+		"Designator",
+		"Part Number",
+		"Description",
+		"Quantity",
+		"Manufacturer",
+		"Manufacturer Part Number",
+		"Value",
+		"Footprint",
+		"Supplier",
+		"Supplier Part Number",
+		"Package",
+		"Tolerance",
+		"Voltage Rating",
+		"Power Rating",
+		"Temperature Coefficient",
+		"Lifecycle Status",
+		"RoHS Status",
+		"Lead Time",
+		"Cost",
+		"Min Order Quantity",
+	}
+)

--- a/go.work
+++ b/go.work
@@ -3,6 +3,7 @@ go 1.22.5
 use (
 	./cmd/BOMulus
 	./config
+	./pkg/components
 	./pkg/core
 	./pkg/export
 	./pkg/gui

--- a/pkg/components/cmp_utils.go
+++ b/pkg/components/cmp_utils.go
@@ -1,0 +1,12 @@
+package components
+
+import "core"
+
+// Calculate total quantity of components.
+func CompTotalQuantity() int {
+	total := 0
+	for _, component := range core.Components {
+		total += component.Quantity
+	}
+	return total
+}

--- a/pkg/components/detection.go
+++ b/pkg/components/detection.go
@@ -1,0 +1,1 @@
+package components

--- a/pkg/components/detection.go
+++ b/pkg/components/detection.go
@@ -1,1 +1,5 @@
 package components
+
+func ComponentsDetection() {
+
+}

--- a/pkg/components/detection.go
+++ b/pkg/components/detection.go
@@ -2,11 +2,11 @@ package components
 
 import (
 	"core"
-	"fmt"
 	"math"
 	"strconv"
 )
 
+// Detect components, can be updated with more specs.
 func ComponentsDetection() {
 	colSafety := math.Max(float64(core.Filters.Quantity), float64(core.Filters.Mpn))
 	for i := core.Filters.Header + 1; i < len(core.XlsmFiles[1].Content); i++ {
@@ -21,5 +21,4 @@ func ComponentsDetection() {
 			core.Components = append(core.Components, component)
 		}
 	}
-	fmt.Println(core.Components)
 }

--- a/pkg/components/detection.go
+++ b/pkg/components/detection.go
@@ -1,5 +1,25 @@
 package components
 
-func ComponentsDetection() {
+import (
+	"core"
+	"fmt"
+	"math"
+	"strconv"
+)
 
+func ComponentsDetection() {
+	colSafety := math.Max(float64(core.Filters.Quantity), float64(core.Filters.Mpn))
+	for i := core.Filters.Header + 1; i < len(core.XlsmFiles[1].Content); i++ {
+		if int(colSafety) < len(core.XlsmFiles[1].Content[i]) {
+			quantity, err := strconv.Atoi(core.XlsmFiles[1].Content[i][core.Filters.Quantity])
+			if err != nil {
+				return
+			}
+			component := core.Component{
+				Quantity: quantity,
+				Mpn:      core.XlsmFiles[1].Content[i][core.Filters.Mpn]}
+			core.Components = append(core.Components, component)
+		}
+	}
+	fmt.Println(core.Components)
 }

--- a/pkg/components/go.mod
+++ b/pkg/components/go.mod
@@ -1,0 +1,3 @@
+module components
+
+go 1.22.5

--- a/pkg/components/header.go
+++ b/pkg/components/header.go
@@ -1,16 +1,27 @@
 package components
 
-import "core"
+import (
+	"core"
+	"fmt"
+	"strings"
+)
 
 // Detect automatically the header row.
 func HeaderDetection() {
 	header := 0
 	for i, row := range core.XlsmFiles[1].Content {
-		for _, col := range row {
+		for j, col := range row {
 			if core.ContainsKeywords(col) {
+				switch strings.ToLower(strings.ReplaceAll(col, " ", "")) {
+				case "quantity":
+					core.Filters.Quantity = j
+				case "manufacturerpartnumber":
+					core.Filters.Mpn = j
+				}
 				header = i
 			}
 		}
 	}
 	core.Filters.Header = header + 1
+	fmt.Println(core.Filters.Quantity, core.Filters.Mpn)
 }

--- a/pkg/components/header.go
+++ b/pkg/components/header.go
@@ -1,0 +1,16 @@
+package components
+
+import "core"
+
+// Detect automatically the header row.
+func HeaderDetection() {
+	header := 0
+	for i, row := range core.XlsmFiles[1].Content {
+		for _, col := range row {
+			if core.ContainsKeywords(col) {
+				header = i
+			}
+		}
+	}
+	core.Filters.Header = header + 1
+}

--- a/pkg/components/header.go
+++ b/pkg/components/header.go
@@ -2,7 +2,6 @@ package components
 
 import (
 	"core"
-	"fmt"
 	"strings"
 )
 
@@ -23,5 +22,4 @@ func HeaderDetection() {
 		}
 	}
 	core.Filters.Header = header + 1
-	fmt.Println(core.Filters.Quantity, core.Filters.Mpn)
 }

--- a/pkg/core/models.go
+++ b/pkg/core/models.go
@@ -14,12 +14,20 @@ type XlsmDelta struct {
 }
 
 type Filter struct {
-	Equal  bool
-	Delete bool
-	Insert bool
-	Update bool
-	Swap   bool
-	Header int
+	Equal    bool
+	Delete   bool
+	Insert   bool
+	Update   bool
+	Swap     bool
+	Header   int
+	Quantity int
+	Mpn      int
+}
+
+// As a starting point.
+type Component struct {
+	Quantity int
+	Mpn      string
 }
 
 var XlsmFiles = []XlsmFile{
@@ -29,7 +37,9 @@ var XlsmFiles = []XlsmFile{
 
 var XlsmDeltas []XlsmDelta
 
-var Filters = Filter{true, true, true, true, false, 0}
+var Filters = Filter{true, true, true, true, false, 0, 0, 0}
+
+var Components = []Component{}
 
 func ResetContent() {
 	XlsmFiles[0].Content = nil

--- a/pkg/core/tools.go
+++ b/pkg/core/tools.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 )
 
 // Determine the maximum number of columns.
@@ -52,9 +53,12 @@ func ContainsInteger(slice []int, i int) bool {
 }
 
 // Function to now if keywords contains s.
+// Maybe add a tolower filter...
 func ContainsKeywords(s string) bool {
+	normalizedInput := strings.ToLower(strings.ReplaceAll(s, " ", ""))
 	for _, keyword := range config.HEADER_KEYWORDS {
-		if keyword == s {
+		normalizedKeyword := strings.ToLower(strings.ReplaceAll(keyword, " ", ""))
+		if normalizedKeyword == normalizedInput {
 			return true
 		}
 	}

--- a/pkg/core/tools.go
+++ b/pkg/core/tools.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"config"
 	"fmt"
 	"io"
 	"os"
@@ -50,20 +51,15 @@ func ContainsInteger(slice []int, i int) bool {
 	return false
 }
 
-/*
-// Function to determine max width of column for export.
-func MaxColWidth(i int) float64 {
-	maxWidth := 0.0
-	for _, row := range XlsmFiles[1].Content {
-		for j, cell := range row {
-			if i == j && float64(len(cell)) > maxWidth {
-				maxWidth = float64(len(cell))
-			}
+// Function to now if keywords contains s.
+func ContainsKeywords(s string) bool {
+	for _, keyword := range config.HEADER_KEYWORDS {
+		if keyword == s {
+			return true
 		}
 	}
-	return maxWidth
+	return false
 }
-*/
 
 // Function to duplicate a file.
 func CopyFile(src, dst string) error {

--- a/pkg/gui/btn_compare.go
+++ b/pkg/gui/btn_compare.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"components"
 	"config"
 	"core"
 
@@ -20,6 +21,8 @@ func BtnCompare(button *gtk.Button) {
 	}
 	// Read and store both Xlsm files.
 	core.XlsmReader()
+	// Try to detect automatically the header.
+	components.HeaderDetection()
 	// Generate delta data.
 	core.XlsmDiff()
 	// Update the view

--- a/pkg/gui/btn_compare.go
+++ b/pkg/gui/btn_compare.go
@@ -23,6 +23,8 @@ func BtnCompare(button *gtk.Button) {
 	core.XlsmReader()
 	// Try to detect automatically the header.
 	components.HeaderDetection()
+	// Try to dedect components.
+	components.ComponentsDetection()
 	// Generate delta data.
 	core.XlsmDiff()
 	// Update the view

--- a/pkg/gui/diff_summary.go
+++ b/pkg/gui/diff_summary.go
@@ -1,6 +1,7 @@
 package gui
 
 import (
+	"components"
 	"config"
 	"core"
 	"fmt"
@@ -23,8 +24,8 @@ func DiffSummary() *gtk.Label {
 	}
 	// Create a label with a formatted text.
 	diffSummaryText := fmt.Sprintf(
-		"<span foreground='%s'>--- DELETES   %d</span>%s<span foreground='%s'>+++ INSERTS   %d</span>%s<span foreground='%s'>-+- UPDATES   %d</span>",
-		config.DELETE_BG_COLOR, deleteCount, config.SUMMARY_SPACING, config.INSERT_BG_COLOR, insertCount, config.SUMMARY_SPACING, config.OLD_UPDATE_BG_COLOR, updateCount,
+		"<span foreground='%s'>--- DELETES   %d</span>%s<span foreground='%s'>+++ INSERTS   %d</span>%s<span foreground='%s'>-+- UPDATES   %d</span>%s<span>∑ COMPONENTS   %d</span>",
+		config.DELETE_BG_COLOR, deleteCount, config.SUMMARY_SPACING, config.INSERT_BG_COLOR, insertCount, config.SUMMARY_SPACING, config.OLD_UPDATE_BG_COLOR, updateCount, config.SUMMARY_SPACING, components.CompTotalQuantity(),
 	)
 	diffSummaryLabel, err := gtk.LabelNew("")
 	if err != nil {


### PR DESCRIPTION
- Header is now detected automatically:
(Row number found replace the initial number on the spinButton made to manually change the header line, so you can use it as a starting point.)
(Keywords used for the detection can be updated using the config file.)
(During header detection, columns are also detected to facilitate components detection.)

- All components are now stored automatically with for now basic infos like Quantity and Manufacturer Part Number.
- Total components quantity is now displayed aside of the diff summary. 